### PR TITLE
added color config fix

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -39,6 +39,10 @@ set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'dreamsofcode-io/catppuccin-tmux'
 set -g @plugin 'tmux-plugins/tmux-yank'
 
+# set color default to display nvim colorschemes correctly
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+
 run '~/.tmux/plugins/tpm/tpm'
 
 # set vi-mode


### PR DESCRIPTION
tried to use tmux with this config with neovim. noticed that my neovim color scheme(kanagawa,nvim) was not displaying correctly only when using tmux. added fix to make tmux display color scheme correctly 