### PR TITLE
Update `setoption -sa` to `setoption -gsa` to make it work with newer versions of tmux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,4 +1,4 @@
-set-option -sa terminal-overrides ",xterm*:Tc"
+set-option -gsa terminal-overrides ",xterm*:Tc"
 set -g mouse on
 
 unbind C-b
@@ -7,7 +7,7 @@ bind C-Space send-prefix
 
 # Vim style pane selection
 bind h select-pane -L
-bind j select-pane -D 
+bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 


### PR DESCRIPTION
I used your config and noticed a couple of errors when using it with tmux 3.4

changing the first line from 
```
set-option -sa terminal-overrides ",xterm*:Tc"
```
to
```
set-option -gsa terminal-overrides ",xterm*:Tc"
```
seemed to fix the issue